### PR TITLE
[feat] SrollToTop 버튼 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Header } from "@/components/layout/Header";
+import { ScrollToTop } from "@/components/layout/ScrollToTop";
 import { About } from "@/components/sections/About";
 import { Hero } from "@/components/sections/Hero";
 import { Projects } from "@/components/sections/Projects";
@@ -6,14 +7,13 @@ import { Skills } from "@/components/sections/Skills";
 
 export default function Home() {
   return (
-    <div className="min-h-screen">
-      <main>
-        <Header />
-        <Hero />
-        <About />
-        <Skills />
-        <Projects />
-      </main>
-    </div>
+    <main className="min-h-screen">
+      <Header />
+      <Hero />
+      <About />
+      <Skills />
+      <Projects />
+      <ScrollToTop />
+    </main>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -44,13 +44,7 @@ export function Header() {
     >
       <div className="section-container">
         <div className="flex items-center justify-between h-16 md:h-20">
-          <Link
-            href={"#hero"}
-            onClick={() => handleNavClick("hero")}
-            className="text-xl md:text-2xl font-bold hover:text-emerald-200 transition-colors"
-          >
-            {"Portfolio"}
-          </Link>
+          <h1 className="text-2xl font-semi-bold">Portfolio</h1>
 
           {/* 데스크탑 네비게이션 */}
           <nav className="hidden md:flex items-center space-x-8">

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { FaArrowUp } from "react-icons/fa";
+
+export function ScrollToTop() {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  const toggleVisibility = () => {
+    if (window.pageYOffset > 300) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  const scrollToTop = () => {
+    const hereElement = document.getElementById("hero");
+    if (hereElement) {
+      hereElement.scrollIntoView({ behavior: "smooth" });
+    } else {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.button
+          onClick={scrollToTop}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          transition={{ duration: 0.2 }}
+          aria-label="맨 위로 이동"
+          className="fixed bottom-8 right-8 z-50 p-3 rounded-full bg-emerald-500 text-white shadow-lg hover:bg-emerald-600 transition-all"
+        >
+          <FaArrowUp className="w-5 h-5" />
+        </motion.button>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -14,7 +14,7 @@ export function About() {
       <div className="section-container">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
-            About me
+            About Me
           </h2>
         </div>
 


### PR DESCRIPTION
- 최상단(hero 섹션)으로 이동하는 부분 리팩토링
  - 기존 좌측 상단의 Portfolio(로고 위치)를 클릭할 경우 최상단으로 이동했음
  - 별도의 우측 하단의 버튼을 통해 최상단으로 이동하도록 UX를 개선
- ScrollToTop 구현
  - 스크롤을 일정(300px)부분 내리면 버튼이 보이도록 구현
  - 기존 Portfolio(로고 위치)는 웹 사이트로 이동하는 식으로 구현할 예정