### PR TITLE
[feat] 반응형 디자인을 위한 애니메이션 동적 제어 기능 추가

### DIFF
--- a/src/components/common/AnimatedSection.tsx
+++ b/src/components/common/AnimatedSection.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { useInView } from "@/hooks/useInView";
+import { useEffect, useState } from "react";
 
 interface AnimatedSectionProps {
   children: React.ReactNode;
@@ -40,13 +41,31 @@ export function AnimatedSection({
   animation = "slide-up",
 }: AnimatedSectionProps) {
   const { ref, inView } = useInView();
+  const [currentAnimation, setCurrentAnimation] = useState(animation);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (
+        window.innerWidth < 768 &&
+        (animation === "slide-left" || animation === "slide-right")
+      ) {
+        setCurrentAnimation("slide-up");
+      } else {
+        setCurrentAnimation(animation);
+      }
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [animation]);
 
   return (
     <motion.div
       ref={ref}
       initial="hidden"
       animate={inView ? "visible" : "hidden"}
-      variants={animations[animation]}
+      variants={animations[currentAnimation]}
       transition={{ duration: 0.5, delay, ease: "easeInOut" }}
       className={className}
     >


### PR DESCRIPTION
- `AnimatedSection` 컴포넌트에 `useEffect` 훅을 추가하여 뷰포트 크기를 감지하도록 구현
- 화면 너비가 md(768px) 미만일 경우 'slide-left', 'slide-right' 애니메이션을 'slide-up'으로 고정
  - 작은 화면에서는 위로 올라오는 애니메이션을 이용하도록 하는게 UX적으로 좋은 것 같음