### PR TITLE
[fix] 프로필 이미지 버그 수정

### DIFF
--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -21,7 +21,7 @@ export function About() {
 
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           <AnimatedSection animation="slide-left">
-            <div className="relative justify-self-center bg-gray-700/50 p-4 rounded-2xl shadow-lg">
+            <div className="relative mx-auto w-fit bg-gray-700/50 p-4 rounded-2xl shadow-lg">
               <div className="relative w-64 h-80 lg:w-72 lg:h-96">
                 <Image
                   src="/profile.jpg"


### PR DESCRIPTION
- `AnimatedSection` 을 적용하면서 `justify-self-center` css 속성의 오류가 발생
  - `justify-self-center`가 적용된 `div`는 `grid` 레이아웃의 직접적인 자식 요소에만 적용이 되지만 부모는 `AnimatedSection`으로 클래스가 제대로 동작하지 않는 문제 발생
- 해결
  - `justify-self-center` 클래스를 제거하고, `mx-auto`, `w-fit` 클래스를 추가하여 이미지가 모든 화면에서 중앙에 위치하도록 수정