### PR TITLE
[fix] 모바일 scroll 버그 수정

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,9 +20,11 @@ export function Header() {
   }, []);
 
   const handleNavClick = (id: string) => {
-    const element = document.getElementById(id);
-    element?.scrollIntoView({ behavior: "smooth" });
     setIsMobileMenuOpen(false);
+    setTimeout(() => {
+      const element = document.getElementById(id);
+      element?.scrollIntoView({ behavior: "smooth" });
+    }, 100);
   };
 
   return (
@@ -75,7 +77,7 @@ export function Header() {
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
               exit={{ opacity: 0, height: 0 }}
-              className="md:hidden border-t border-gray-200 drak:border-gray-700 bg-white dark:bg-gray-900"
+              className="md:hidden border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
             >
               <div className="py-4 space-y-2">
                 {NAVIGATION_ITEMS.map((item) => (


### PR DESCRIPTION
- 화면이 작아질 경우 모바일 메뉴를 통해 각 섹션으로 이동할 수 있지만 클릭을해도 이동(스크롤)이 안되는 문제 발생
  - `setIsMobileMenuOpen`과 `element.scrollIntoView`가 동시에 일어나 동작이 충돌하여 이동하지 않았음
  - 모바일 메뉴에서 특정 메뉴 클릭 시 바로 `setIsMobileMenuOpen` 설정을 하고 일정 시간(100ms)뒤에 scroll 이벤트가 동작하도록 수정