### PR TITLE
[fix] AnimatedSection padding 오류 해결

### DIFF
--- a/src/components/common/AnimatedSection.tsx
+++ b/src/components/common/AnimatedSection.tsx
@@ -41,31 +41,13 @@ export function AnimatedSection({
   animation = "slide-up",
 }: AnimatedSectionProps) {
   const { ref, inView } = useInView();
-  const [currentAnimation, setCurrentAnimation] = useState(animation);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (
-        window.innerWidth < 768 &&
-        (animation === "slide-left" || animation === "slide-right")
-      ) {
-        setCurrentAnimation("slide-up");
-      } else {
-        setCurrentAnimation(animation);
-      }
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, [animation]);
 
   return (
     <motion.div
       ref={ref}
       initial="hidden"
       animate={inView ? "visible" : "hidden"}
-      variants={animations[currentAnimation]}
+      variants={animations[animation]}
       transition={{ duration: 0.5, delay, ease: "easeInOut" }}
       className={className}
     >

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -3,10 +3,13 @@
 import Image from "next/image";
 import { BsDownload } from "react-icons/bs";
 import { AnimatedSection } from "../common/AnimatedSection";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 const keywords = ["사용자 경험(UX)", "협업 & 소통", "도전", "긍정적 사고"];
 
 export function About() {
+  const isLarge = useMediaQuery("(min-width: 1024px)");
+
   return (
     <section
       id="about"
@@ -22,7 +25,7 @@ export function About() {
         </AnimatedSection>
 
         <div className={`grid lg:grid-cols-2 gap-12 items-center`}>
-          <AnimatedSection animation="slide-left">
+          <AnimatedSection animation={isLarge ? "slide-left" : "slide-up"}>
             <div
               className={`relative mx-auto w-fit bg-emerald-300/40 dark:bg-emerald-200/60 p-4 rounded-2xl shadow-lg`}
             >
@@ -38,7 +41,7 @@ export function About() {
           </AnimatedSection>
 
           <AnimatedSection
-            animation="slide-right"
+            animation={isLarge ? "slide-right" : "slide-up"}
             className={`space-y-6 text-center lg:text-left`}
           >
             <h3

--- a/src/hooks/useInView.tsx
+++ b/src/hooks/useInView.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useInView as useInViewObserver } from "react-intersection-observer";
 
 interface UseInViewOptions {

--- a/src/hooks/useMediaQuery.tsx
+++ b/src/hooks/useMediaQuery.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState<boolean>(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const listener = () => setMatches(media.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
- 화면이 줄어들 때 `About`의 특정 요소가 `slide-right` -> `slide-up`으로 수정되도록 `AnimatedSection` 내부 `useEffect`를 구현했음
  - `About` 섹션 외에 다른 섹션을 기준으로 화면을 줄일 경우 `About` 섹션의 padding이 생기는 오류가 발생
  - `slide-right`의 경우 `slide-up`으로 바뀌기전 우측에 50px 여백 공간이 존재하기 때문에 여백의 padding이 보이는 것처럼 보이게 됨
- `AnimatedSection` 내부에서 animation을 바꾸는 것이 아닌 외부에서 미리 계산하여 animation을 prop로 넘기도록 수정
  - useMediaQuery 훅을 구현하여 웹 브라우저의 화면 크기를 계산
  - 입력한 query(프로젝트에서는 width값)에 따라 boolean 값 리턴