### PR TITLE
[feat] 섹션 헤더에 강조 효과 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,3 +66,19 @@
   animation: waving-hand 2s ease-in-out infinite;
   transform-origin: 70% 70%;
 }
+
+.section-header {
+  @apply relative inline-flex text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4;
+}
+
+.section-header::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 4px;
+  background: #22c55e;
+  filter: blur(2px);
+  opacity: 0.8;
+}

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -17,11 +17,7 @@ export function About() {
     >
       <div className={`section-container`}>
         <AnimatedSection animation="fade" className={`text-center mb-16`}>
-          <h2
-            className={`text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4`}
-          >
-            About Me
-          </h2>
+          <h2 className={`section-header`}>About Me</h2>
         </AnimatedSection>
 
         <div className={`grid lg:grid-cols-2 gap-12 items-center`}>

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -12,11 +12,7 @@ export function Projects() {
     >
       <div className={`section-container`}>
         <AnimatedSection animation="fade" className={`text-center mb-16`}>
-          <h2
-            className={`text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4`}
-          >
-            Projects
-          </h2>
+          <h2 className={`section-header`}>Projects</h2>
         </AnimatedSection>
 
         <div className={`grid gap-8 md:grid-cols-2 lg:grid-cols-3`}>

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -27,12 +27,8 @@ export function Skills() {
       className={`section-padding bg-stone-100 dark:bg-gray-800`}
     >
       <div className={`section-container`}>
-        <AnimatedSection animation="fade" className={`mb-16`}>
-          <h2
-            className={`text-center text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4`}
-          >
-            Skills
-          </h2>
+        <AnimatedSection animation="fade" className={`text-center mb-16`}>
+          <h2 className={`section-header`}>Skills</h2>
         </AnimatedSection>
 
         <AnimatedSection animation="slide-up">

--- a/src/components/ui/projectCard.tsx
+++ b/src/components/ui/projectCard.tsx
@@ -10,7 +10,7 @@ interface ProjectCardProps {
 export function ProjectCard({ project }: ProjectCardProps) {
   return (
     <section
-      className={`overflow-hidden flex flex-col justify-start gap-8 rounded-2xl bg-stone-100 dark:bg-gray-800 relative h-[23rem] group  transition-transform transition-shadow duration-300 ease-out hover:shadow-xl hover:-translate-y-2`}
+      className={`overflow-hidden flex flex-col justify-start gap-8 rounded-2xl bg-stone-100 dark:bg-gray-800 relative h-[23rem] group transition-transform transition-shadow duration-300 ease-out hover:shadow-xl hover:-translate-y-2`}
     >
       {project.image && (
         <div className="relative h-48 overflow-hidden">


### PR DESCRIPTION
- `underline`을 이용하여 섹션 헤더에 강조 효과 추가
  - 헤더 섹션을 좀 더 강조하기 위해 설정
- 기존 header에 설정된 CSS를 global로 설정 `section-header`
  - 추가로 `section-header`에 `underline` 관련 CSS 설정 추가