### PR TITLE
[fix] CRLF 줄바꿈 오류 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "plugin:prettier/recommended"
   ],
   "rules": {
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "react/display-name": "off",
     "react/no-unescaped-entities": "off",
     "react/jsx-sort-props": [
@@ -20,12 +20,7 @@
     ],
     "no-unused-vars": "warn",
     "@typescript-eslint/no-unused-vars": "warn",
-    "no-console": [
-      "warn",
-      {
-        "allow": ["warn", "error"]
-      }
-    ],
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
     "prefer-const": "error"
   }
 }


### PR DESCRIPTION
- 문제 : 줄바 문자 불일치
  - 윈도우(window)는 줄바꿈을 나타낼 때 CRLF(`\r\n`)를 사용하는데 리눅스(Linux)나 macOS는 LF(`\n`)만 사용
  - `Prettier`의 표준은 `LF`를 표준으로 사용하여 윈도우 환경에서 CRLF 줄바꿈 문자를 불필요한 문자로 인식하여 에러를 띄움
- 해결
  - .eslintrc 파일에 `endofLine: auto` 설정을 추가하여 `Prettier`가 파일을 검사할 때 해당 파일이 어떤 운영체제에서 만들어졌는지 자동으로 감지하여 CRLF/LF 불일치 문제를 해결