### PR TITLE
[refactor] Project 섹션 서버 컴포넌트 전환 및 App Router적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
+      "integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1356,17 +1356,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.41.0.tgz",
-      "integrity": "sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.42.0.tgz",
+      "integrity": "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/type-utils": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/type-utils": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1380,7 +1380,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.41.0",
+        "@typescript-eslint/parser": "^8.42.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1396,16 +1396,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.41.0.tgz",
-      "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
+      "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1421,14 +1421,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.41.0.tgz",
-      "integrity": "sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
+      "integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.41.0",
-        "@typescript-eslint/types": "^8.41.0",
+        "@typescript-eslint/tsconfig-utils": "^8.42.0",
+        "@typescript-eslint/types": "^8.42.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1443,14 +1443,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.41.0.tgz",
-      "integrity": "sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
+      "integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0"
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1461,9 +1461,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.41.0.tgz",
-      "integrity": "sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
+      "integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1478,15 +1478,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.41.0.tgz",
-      "integrity": "sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.42.0.tgz",
+      "integrity": "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1503,9 +1503,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.41.0.tgz",
-      "integrity": "sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
+      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1517,16 +1517,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.41.0.tgz",
-      "integrity": "sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
+      "integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.41.0",
-        "@typescript-eslint/tsconfig-utils": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/project-service": "8.42.0",
+        "@typescript-eslint/tsconfig-utils": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1572,16 +1572,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.41.0.tgz",
-      "integrity": "sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.42.0.tgz",
+      "integrity": "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0"
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1596,13 +1596,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.41.0.tgz",
-      "integrity": "sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
+      "integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/types": "8.42.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -2834,9 +2834,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-      "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+      "version": "1.5.213",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.213.tgz",
+      "integrity": "sha512-xr9eRzSLNa4neDO0xVFrkXu3vyIzG4Ay08dApecw42Z1NbmCt+keEpXdvlYGVe0wtvY5dhW0Ay0lY0IOfsCg0Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5139,17 +5139,17 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.5.tgz",
-      "integrity": "sha512-uAeQQwByI6dfV7wpt/gVqg+jAPaSp8WwOA8kKC/dv1qw14oGpnpAisY65ibGHUGDUv0rYaZ8CAJZ/1U8hUvC2A==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.6.tgz",
+      "integrity": "sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.5.0",
+        "chalk": "^5.6.0",
         "commander": "^14.0.0",
         "debug": "^4.4.1",
         "lilconfig": "^3.1.3",
-        "listr2": "^9.0.1",
+        "listr2": "^9.0.3",
         "micromatch": "^4.0.8",
         "nano-spawn": "^1.0.2",
         "pidtree": "^0.6.0",

--- a/prisma/migrations/20250903083020_init_tables/migration.sql
+++ b/prisma/migrations/20250903083020_init_tables/migration.sql
@@ -14,6 +14,7 @@ CREATE TABLE "public"."Project" (
     "image" TEXT,
     "githubUrl" TEXT,
     "liveUrl" TEXT,
+    "slug" TEXT NOT NULL,
 
     CONSTRAINT "Project_pkey" PRIMARY KEY ("id")
 );
@@ -67,6 +68,9 @@ CREATE TABLE "public"."User" (
 
     CONSTRAINT "User_pkey" PRIMARY KEY ("id")
 );
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_slug_key" ON "public"."Project"("slug");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "ProjectInfo_projectId_key" ON "public"."ProjectInfo"("projectId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,60 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Project {
+  id           String       @id
+  title        String
+  summary      String
+  descriptions String[]     @default([])
+  technologies String[]     @default([])
+  image        String?
+  githubUrl    String?
+  liveUrl      String?
+  slug         String       @unique
+  info         ProjectInfo?
+  tasks        TaskItem[]
+}
+
+model ProjectInfo {
+  id        String      @id @default(uuid())
+  type      ProjectType
+  name      String
+  period    String
+  members   String
+  projectId String      @unique
+  project   Project     @relation(fields: [projectId], references: [id])
+}
+
+model TaskItem {
+  id           String   @id
+  title        String
+  issue        String
+  solutions    String[] @default([])
+  achievements String[] @default([])
+  projectId    String
+  project      Project  @relation(fields: [projectId], references: [id])
+}
+
+model Skill {
+  id       Int           @id
+  name     String        @unique
+  category SkillCategory
+  iconUrl  String
+}
+
+model User {
+  id                String  @id @default(uuid())
+  name              String
+  email             String?
+  phone             String?
+  linkedin          String?
+  blog              String?
+  github            String?
+  profileImageUrl   String?
+  resumeUrl         String?
+  workExperienceUrl String?
+}
+
 enum ProjectType {
   Company
   Team
@@ -18,60 +72,4 @@ enum SkillCategory {
   Backend
   Database
   Others
-}
-
-model Project {
-  id String @id
-  title String
-  summary String
-  descriptions String[] @default([])
-  technologies String[] @default([])
-  image String?
-  githubUrl String?
-  liveUrl String?
-
-  info ProjectInfo?
-  tasks TaskItem[]
-}
-
-model ProjectInfo {
-  id String @id @default(uuid())
-  type ProjectType
-  name String
-  period String
-  members String
-
-  projectId String @unique
-  project Project @relation(fields: [projectId], references: [id])
-}
-
-model TaskItem {
-  id String @id
-  title String
-  issue String
-  solutions String[] @default([])
-  achievements String[] @default([])
-
-  projectId String
-  project Project @relation(fields: [projectId], references: [id])
-}
-
-model Skill {
-  id Int @id
-  name String @unique
-  category SkillCategory
-  iconUrl String
-}
-
-model User {
-  id String @id @default(uuid())
-  name String
-  email String?
-  phone String?
-  linkedin String?
-  blog String?
-  github String?
-  profileImageUrl String?
-  resumeUrl String?
-  workExperienceUrl String?
 }

--- a/src/app/@modal/(.)[slug]/page.tsx
+++ b/src/app/@modal/(.)[slug]/page.tsx
@@ -1,0 +1,20 @@
+import { ProjectModal } from "@/components/ui/ProjectModal";
+import { getProjectBySlug } from "@/lib/projects";
+import { notFound } from "next/navigation";
+
+interface ModalPageProps {
+  params: { slug: string };
+}
+
+export default async function InterceptedProjectModal({
+  params,
+}: ModalPageProps) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+
+  if (!project) {
+    notFound();
+  }
+
+  return <ProjectModal project={project} />;
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { ProjectModal } from "@/components/ui/ProjectModal";
+import { getProjectBySlug } from "@/lib/projects";
+import { notFound } from "next/navigation";
+
+interface ProjectPageProps {
+  params: { slug: string };
+}
+
+export default async function ProjectPage({ params }: ProjectPageProps) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-gray-900">
+      <div className="container mx-auto px-4 py-8">
+        <ProjectModal project={project} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: {
   children: React.ReactNode;
+  modal: React.ReactNode;
 }) {
   return (
     <html suppressHydrationWarning lang="ko">
@@ -41,6 +43,7 @@ export default function RootLayout({
           <div className={`min-h-screen`}>
             <Header />
             <main>{children}</main>
+            {modal}
             <ScrollToTop />
             <Footer />
           </div>

--- a/src/components/sections/ProjectList.tsx
+++ b/src/components/sections/ProjectList.tsx
@@ -1,48 +1,23 @@
-"use client";
-
-import { useState } from "react";
 import { Project } from "@/types";
 import { AnimatedSection } from "../common/AnimatedSection";
 import { ProjectCard } from "../ui/ProjectCard";
-import { ProjectModal } from "../ui/ProjectModal";
 
 interface ProjectListProps {
   projects: Project[];
 }
 
 export function ProjectList({ projects }: ProjectListProps) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-
-  const handleOpenModal = (project: Project) => {
-    setSelectedProject(project);
-    setIsModalOpen(true);
-  };
-
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-    setSelectedProject(null);
-  };
-
   return (
-    <>
-      <div className={`grid gap-8 md:grid-cols-2 lg:grid-cols-3`}>
-        {projects.map((project) => (
-          <AnimatedSection
-            key={project.id}
-            className={`animate-slide-up`}
-            delay={parseFloat(project.id) * 0.1}
-          >
-            <ProjectCard
-              openDetailModal={() => handleOpenModal(project)}
-              project={project}
-            />
-          </AnimatedSection>
-        ))}
-      </div>
-      {isModalOpen && selectedProject && (
-        <ProjectModal project={selectedProject} onClose={handleCloseModal} />
-      )}
-    </>
+    <div className={`grid gap-8 md:grid-cols-2 lg:grid-cols-3`}>
+      {projects.map((project) => (
+        <AnimatedSection
+          key={project.id}
+          className={`animate-slide-up`}
+          delay={parseFloat(project.id) * 0.1}
+        >
+          <ProjectCard project={project} />
+        </AnimatedSection>
+      ))}
+    </div>
   );
 }

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -1,18 +1,18 @@
 import { Project } from "@/types";
 import Image from "next/image";
+import Link from "next/link";
 import { HiOutlineArrowRight } from "react-icons/hi";
 
 interface ProjectCardProps {
   project: Project;
-  openDetailModal: () => void;
 }
 
-export function ProjectCard({ project, openDetailModal }: ProjectCardProps) {
+export function ProjectCard({ project }: ProjectCardProps) {
   return (
     <section
-      className={`overflow-hidden flex flex-col justify-start gap-8 rounded-2xl bg-stone-100 dark:bg-gray-800 
-        relative h-[23rem] group transition-transform duration-300 ease-out hover:shadow-xl 
-        hover:-translate-y-2`}
+      className={`overflow-hidden flex flex-col justify-start gap-8 rounded-2xl bg-stone-100 dark:bg-gray-800
+         relative h-[23rem] group transition-transform duration-300 ease-out hover:shadow-xl
+         hover:-translate-y-2`}
       id="ProjectCard"
     >
       {project.image && (
@@ -33,10 +33,10 @@ export function ProjectCard({ project, openDetailModal }: ProjectCardProps) {
           <div
             className={`px-2 py-1 bg-emerald-300/50 dark:bg-emerald-400/40 text-gray-600 dark:text-gray-200 rounded-full text-sm font-semibold mr-2`}
           >
-            {project.info.name}
+            {project.info?.name}
           </div>
           <span className={`text-gray-600 dark:text-gray-400 text-sm`}>
-            {project.info.period}
+            {project.info?.period}
           </span>
         </div>
 
@@ -56,19 +56,19 @@ export function ProjectCard({ project, openDetailModal }: ProjectCardProps) {
       </div>
 
       <div
-        className={`absolute z-[3] flex flex-col items-center justify-center gap-10 text-black dark:text-white w-full 
-          h-full p-5 hover:bg-stone-100 dark:hover:bg-gray-800 opacity-0 transition group-hover:opacity-100`}
+        className={`absolute z-[3] flex flex-col items-center justify-center gap-10 text-black dark:text-white w-full
+           h-full p-5 hover:bg-stone-100 dark:hover:bg-gray-800 opacity-0 transition group-hover:opacity-100`}
       >
         <h3 className={`font-bold text-2xl group-hover:text-center`}>
           {project.title}
         </h3>
         <div className={`w-2/3 flex flex-col gap-3`}>
-          <button
-            className={`primary-button px-6 py-3 rounded-lg`}
-            onClick={openDetailModal}
+          <Link
+            className={`primary-button px-6 py-3 rounded-lg text-center`}
+            href={`/${project.slug}`}
           >
             자세히보기
-          </button>
+          </Link>
           {project.githubUrl && (
             <a
               className={`primary-button px-6 py-3 rounded-lg`}

--- a/src/components/ui/ProjectModal.tsx
+++ b/src/components/ui/ProjectModal.tsx
@@ -1,6 +1,5 @@
-import { useEffect } from "react";
 import { Project } from "@/types";
-import { IoMdClose } from "react-icons/io";
+import { ProjectModalClient } from "./ProjectModalClient";
 import { FcCalendar } from "react-icons/fc";
 import { FaBuilding, FaUsers, FaUser } from "react-icons/fa";
 import { CollapsibleSection } from "./CollapsibleSection";
@@ -8,30 +7,11 @@ import { HiOutlineArrowRight } from "react-icons/hi";
 
 interface ProjectModalProps {
   project: Project;
-  onClose: () => void;
 }
 
-export function ProjectModal({ project, onClose }: ProjectModalProps) {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = "unset";
-    };
-  }, [onClose]);
-
-  if (!project) return null;
-
+export function ProjectModal({ project }: ProjectModalProps) {
   const renderIcon = () => {
-    switch (project.info.type) {
+    switch (project.info?.type) {
       case "Company":
         return <FaBuilding className={`w-4 h-4 mr-2 text-blue-500`} />;
       case "Team":
@@ -44,111 +24,94 @@ export function ProjectModal({ project, onClose }: ProjectModalProps) {
   };
 
   return (
-    <div
-      className={`fixed inset-0 bg-black/50 backdrop-blur-sm flex justify-center items-center z-50`}
-      id="ProjectModal"
-      onClick={onClose}
-    >
-      <div
-        className={`bg-stone-100 dark:bg-gray-800 rounded-lg p-8 m-4 max-w-3xl w-full relative max-h-[90vh] overflow-y-auto`}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <button
-          aria-label="Close modal"
-          className={`primary-button sticky top-0 left-full ml-4 -mt-1 -mr-1 z-10 rounded-full px-2 py-2`}
-          onClick={onClose}
-        >
-          <IoMdClose className={`w-5 h-5`} />
-        </button>
+    <ProjectModalClient>
+      <div className={`-mt-12 pt-4`}>
+        <div className={`flex items-start justify-between mb-6`}>
+          <h2
+            className={`text-2xl md:text-3xl font-bold text-gray-900 dark:text-white pr-16`}
+          >
+            {project.title}
+          </h2>
+        </div>
 
-        <div className={`-mt-12 pt-4`}>
-          <div className={`flex items-start justify-between mb-6`}>
-            <h2
-              className={`text-2xl md:text-3xl font-bold text-gray-900 dark:text-white pr-16`}
+        <div className={`space-y-6`}>
+          <div
+            className={`flex items-center text-sm text-gray-600 dark:text-gray-400`}
+          >
+            {renderIcon()}
+            <span
+              className={`font-semibold text-lg mr-2 text-gray-700 dark:text-gray-300`}
             >
-              {project.title}
-            </h2>
+              {project.info?.name}
+            </span>
+            {project.info?.members && (
+              <span className={`text-gray-600 dark:text-gray-400`}>
+                ({project.info?.members})
+              </span>
+            )}
           </div>
 
-          <div className={`space-y-6`}>
-            <div
-              className={`flex items-center text-sm text-gray-600 dark:text-gray-400`}
+          <div
+            className={`flex items-center text-sm text-gray-600 dark:text-gray-400`}
+          >
+            <FcCalendar className={`w-4 h-4 mr-2`} />
+            <span>{project.info?.period}</span>
+          </div>
+
+          <div>
+            <h3
+              className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
             >
-              {renderIcon()}
-              <span
-                className={`font-semibold text-lg mr-2 text-gray-700 dark:text-gray-300`}
-              >
-                {project.info.name}
-              </span>
-              {project.info.members && (
-                <span className={`text-gray-600 dark:text-gray-400`}>
-                  ({project.info.members})
-                </span>
-              )}
-            </div>
-
-            <div
-              className={`flex items-center text-sm text-gray-600 dark:text-gray-400`}
-            >
-              <FcCalendar className={`w-4 h-4 mr-2`} />
-              <span>{project.info.period}</span>
-            </div>
-
-            <div>
-              <h3
-                className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
-              >
-                프로젝트 설명
-              </h3>
-              <ul className={`list-disc list-inside space-y-2`}>
-                {project.descriptions.map((desc, index) => (
-                  <li key={index} className={`flex items-start`}>
-                    <HiOutlineArrowRight
-                      className={`w-4 h-4 mt-1.5 mr-2 text-emerald-500 flex-shrink-0`}
-                    />
-                    <p
-                      className={`text-gray-700 dark:text-gray-300 leading-relaxed`}
-                    >
-                      {desc}
-                    </p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <div>
-              <h3
-                className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
-              >
-                사용 기술
-              </h3>
-              <div className={`flex flex-wrap gap-2`}>
-                {project.technologies.map((tech, index) => (
-                  <span
-                    key={index}
-                    className={`bg-stone-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 px-3 py-1 rounded-full text-sm`}
+              프로젝트 설명
+            </h3>
+            <ul className={`list-disc list-inside space-y-2`}>
+              {project.descriptions.map((desc, index) => (
+                <li key={index} className={`flex items-start`}>
+                  <HiOutlineArrowRight
+                    className={`w-4 h-4 mt-1.5 mr-2 text-emerald-500 flex-shrink-0`}
+                  />
+                  <p
+                    className={`text-gray-700 dark:text-gray-300 leading-relaxed`}
                   >
-                    {tech}
-                  </span>
-                ))}
-              </div>
-            </div>
+                    {desc}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
 
-            <div
-              className={`border-t border-gray-400 dark:border-gray-700 pt-6 space-y-4`}
+          <div>
+            <h3
+              className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
             >
-              <h3
-                className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
-              >
-                주요 업무 및 성과
-              </h3>
-              {project.tasks.map((task) => (
-                <CollapsibleSection key={task.id} task={task} />
+              사용 기술
+            </h3>
+            <div className={`flex flex-wrap gap-2`}>
+              {project.technologies.map((tech, index) => (
+                <span
+                  key={index}
+                  className={`bg-stone-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 px-3 py-1 rounded-full text-sm`}
+                >
+                  {tech}
+                </span>
               ))}
             </div>
           </div>
+
+          <div
+            className={`border-t border-gray-400 dark:border-gray-700 pt-6 space-y-4`}
+          >
+            <h3
+              className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
+            >
+              주요 업무 및 성과
+            </h3>
+            {project.tasks.map((task) => (
+              <CollapsibleSection key={task.id} task={task} />
+            ))}
+          </div>
         </div>
       </div>
-    </div>
+    </ProjectModalClient>
   );
 }

--- a/src/components/ui/ProjectModalClient.tsx
+++ b/src/components/ui/ProjectModalClient.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { IoMdClose } from "react-icons/io";
+
+interface ProjectModalClientProps {
+  children: React.ReactNode;
+}
+
+export function ProjectModalClient({ children }: ProjectModalClientProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        router.back();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "unset";
+    };
+  }, [router]);
+
+  const handleCloseClick = () => {
+    if (window.history.length > 2) {
+      router.back();
+    } else {
+      router.push("/");
+    }
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black/50 backdrop-blur-sm flex justify-center items-center z-50 -mt-12 pt-4`}
+      id="ProjectModal"
+    >
+      <div
+        className={`bg-stone-100 dark:bg-gray-800 rounded-lg p-8 m-4 max-w-3xl w-full relative max-h-[90vh] overflow-y-auto`}
+      >
+        <button
+          aria-label="Close modal"
+          className={`primary-button sticky top-0 left-full ml-4 -mt-1 -mr-1 z-10 rounded-full px-2 py-2 close-button`}
+          onClick={handleCloseClick}
+        >
+          <IoMdClose className={`w-5 h-5`} />
+        </button>
+
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,17 @@
+import prisma from "@/lib/prisma";
+
+export async function getProjectBySlug(slug: string) {
+  try {
+    const project = await prisma.project.findUnique({
+      where: { slug },
+      include: {
+        info: true,
+        tasks: true,
+      },
+    });
+    return project;
+  } catch (error) {
+    console.error("프로젝트를 찾을 수 없습니다:", error);
+    return null;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export interface ProjectInfo {
 export interface Project {
   id: string;
   title: string;
+  slug: string;
   info: ProjectInfo | null;
   summary: string;
   descriptions: string[];


### PR DESCRIPTION
- 라우팅 개선
  - 프로젝트 상세 페이지에 대해 `병렬(Parallel)` 및 `인터셉트(Interception)` 라우트를 추가
  - 사용자가 자세히보기 버튼을 클릭할 경우 Modal로 overlay되고, URL을 직접 입력하면 전체 페이지가 렌더링되도록 함
  - `url/slug` 형태로 url이 표현되도록 함
    - `src/app/(.)[slug]/page` : Modal 뷰
    - `src/app/[slug]/page` : Page 뷰
  - `src/app/layout.tsx`에 `modal` 슬롯을 추가하여 병렬 라우트 활성화
- Project 컴포넌트 분리
  - Modal의 상호작용(키보드 이벤트, 닫기 버튼 등) 하는 부분을 `ProjectModalClient`로 분리 (클라이언트 컴포넌트)
- 데이터 로직 분리
  - Project관련 data fetching 로직을 `src/lib/projects.ts` 파일로 분리