### PR TITLE
[refactor] Skill 섹션 개선

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "no-unused-vars": "warn",
     "@typescript-eslint/no-unused-vars": "warn",
     "no-console": ["warn", { "allow": ["warn", "error"] }],
-    "prefer-const": "error"
+    "prefer-const": "error",
+    "@next/next/no-html-link-for-pages": "off"
   }
 }

--- a/src/components/sections/SkillList.tsx
+++ b/src/components/sections/SkillList.tsx
@@ -2,7 +2,7 @@
 
 import { SkillsData } from "@/types";
 import Image from "next/image";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { AnimatedSection } from "../common/AnimatedSection";
 
 const CATEGORIES = {
@@ -23,8 +23,6 @@ export function SkillList({ skills }: SkillListProps) {
   const [activeCategory, setActiveCategory] = useState<SkillCategory>(
     CATEGORIES.All,
   );
-
-  const displayedSkills = useMemo(() => Object.values(skills).flat(), [skills]);
 
   return (
     <>
@@ -49,12 +47,11 @@ export function SkillList({ skills }: SkillListProps) {
       <div
         className={`grid grid-cols-5 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8 gap-4`}
       >
-        {displayedSkills.map((skill, index) => (
+        {skills.All.map((skill, index) => (
           <AnimatedSection
             key={skill.name}
             className={`animate-slide-up relative flex flex-col items-center justify-center gap-2 p-4 bg-white dark:bg-gray-900/50 rounded-lg shadow-md transition-all duration-300 ${
-              skills[activeCategory]?.includes(skill) ||
-              activeCategory === "All"
+              activeCategory === "All" || activeCategory === skill.category
                 ? "group hover:scale-105"
                 : "blur-md opacity-15 pointer-events-none"
             }`}

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -7,25 +7,28 @@ async function getSkills() {
   const skills = await prisma.skill.findMany({
     orderBy: [
       {
-        id: "asc",
+        category: "asc",
       },
       {
-        category: "asc",
+        id: "asc",
       },
     ],
   });
 
-  const skillsData = skills.reduce<Record<string, Skill[]>>((acc, skill) => {
-    const { category } = skill;
-    if (!acc[category]) {
-      acc[category] = [];
-    }
-    acc[category].push({
-      ...skill,
-      icon: skill.iconUrl,
-    });
-    return acc;
-  }, {}) as unknown as SkillsData;
+  const allSkills: Skill[] = skills.map((skill) => ({
+    id: skill.id,
+    name: skill.name,
+    icon: skill.iconUrl,
+    category: skill.category,
+  }));
+
+  const skillsData: SkillsData = {
+    All: allSkills,
+    Frontend: allSkills.filter((skill) => skill.category === "Frontend"),
+    Backend: allSkills.filter((skill) => skill.category === "Backend"),
+    Database: allSkills.filter((skill) => skill.category === "Database"),
+    Others: allSkills.filter((skill) => skill.category === "Others"),
+  };
 
   return skillsData;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export interface Skill {
   id: number;
   name: string;
   icon: string;
+  category: string;
 }
 
 export interface SkillsData {


### PR DESCRIPTION
- 서버에서 데이터를 불러와 카테고리별로 가공하여 클라이언트 컴포넌트에서 바로 사용할 수 있도록 로직 수정
  - `useMemo` 제거, 데이터를 가공할 필요가 없음.