### PR TITLE
[feat] 반응형 UI 및 전역 스타일 리팩토링

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,43 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+
+  h1 {
+    @apply text-[clamp(2rem,6vw,3.5rem)];
+  }
+
+  h2 {
+    @apply text-[clamp(1.5rem,4vw,2.25rem)];
+  }
+
+  h3 {
+    @apply text-[clamp(1.2rem,2.5vw,1.5rem)];
+  }
+
+  h4 {
+    @apply text-[clamp(1rem,3vw,1.125rem)];
+  }
+
+  h5 {
+    @apply text-[clamp(0.875rem,3vw,1.125rem)];
+  }
+
+  p {
+    @apply text-[clamp(0.875rem,2vw,1rem)];
+  }
+
+  small {
+    @apply text-[clamp(0.75rem,1.5vw,0.875rem)];
+  }
+}
+
 @layer components {
+  /* 레이아웃 컴포넌트 */
   .section-container {
     @apply max-w-6xl mx-auto px-4 sm:px-6 lg:px-8;
   }
@@ -10,49 +46,68 @@
   .section-padding {
     @apply py-16 md:py-24;
   }
-}
 
-@layer base {
-  button:not(:disabled),
-  [role="button"]:not(:disabled) {
-    cursor: pointer;
+  /* UI 컴포넌트 */
+  .contact-icon {
+    @apply p-3 bg-white dark:bg-gray-800 rounded-full shadow-lg transition-all duration-300 hover:scale-110 text-gray-700 dark:text-gray-300 hover:text-emerald-300;
+  }
+
+  .contact-icon:hover {
+    @apply shadow-[0_0_20px_rgba(16,185,129,1)] dark:shadow-[0_0_30px_rgba(16,255,200,0.1)];
+  }
+
+  .primary-button {
+    @apply inline-flex items-center justify-center text-[clamp(0.875rem,2vw,1rem)] bg-emerald-500/70 text-white transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-xl;
+  }
+
+  .primary-button:hover {
+    @apply shadow-[0_0_25px_rgba(16,185,129,1)] dark:shadow-[0_0_30px_rgba(16,255,200,0.3)];
+  }
+
+  .section-header {
+    @apply relative mb-[clamp(2rem,5vw,4rem)] inline-flex font-bold text-gray-900 dark:text-white;
+  }
+
+  .section-header::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -6px;
+    width: 100%;
+    height: 4px;
+    background: #22c55e;
+    filter: blur(2px);
+    opacity: 0.8;
+  }
+
+  /* 프로젝트 카드 관련 */
+  .project-card {
+    @apply transition-all duration-300;
+  }
+
+  .mobile-buttons {
+    @apply flex;
+  }
+
+  .hover-overlay {
+    @apply hidden;
+  }
+
+  /* 스킬 관련 */
+  .skill-tooltip {
+    @apply absolute bottom-full mb-[clamp(0.25rem,1vw,0.5rem)] 
+         px-[clamp(0.5rem,2vw,0.75rem)] 
+         py-[clamp(0.25rem,1vw,0.5rem)] 
+         bg-emerald-400/70 text-white 
+         rounded-lg shadow-lg 
+         text-[clamp(0.75rem,1.5vw,0.875rem)] 
+         opacity-0 transition-opacity pointer-events-none z-10
+         text-center;
   }
 }
 
-.contact-icon {
-  @apply p-3 bg-white dark:bg-gray-800 rounded-full shadow-lg transition-all duration-300 hover:scale-110 text-gray-700 dark:text-gray-300 hover:text-emerald-300;
-}
-
-.contact-icon:hover {
-  @apply shadow-[0_0_20px_rgba(16,185,129,1)] dark:shadow-[0_0_30px_rgba(16,255,200,0.1)];
-}
-
-.primary-button {
-  @apply inline-flex items-center justify-center bg-emerald-500/70 text-white transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-xl;
-}
-
-.primary-button:hover {
-  @apply bg-amber-400/50 dark:bg-amber-400/80 hover:text-black;
-}
-
-.section-header {
-  @apply relative inline-flex font-bold text-gray-900 dark:text-white mb-4;
-}
-
-.section-header::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -6px;
-  width: 100%;
-  height: 4px;
-  background: #22c55e;
-  filter: blur(2px);
-  opacity: 0.8;
-}
-
 @layer utilities {
-  /* Enter keyframes */
+  /* 애니메이션 키프레임 정의 */
   @keyframes slide-up {
     from {
       opacity: 0;
@@ -63,6 +118,7 @@
       transform: translateY(0);
     }
   }
+
   @keyframes slide-left {
     from {
       opacity: 0;
@@ -73,6 +129,7 @@
       transform: translateX(0);
     }
   }
+
   @keyframes slide-right {
     from {
       opacity: 0;
@@ -83,6 +140,7 @@
       transform: translateX(0);
     }
   }
+
   @keyframes fade {
     from {
       opacity: 0;
@@ -91,6 +149,7 @@
       opacity: 1;
     }
   }
+
   @keyframes scale-in {
     from {
       opacity: 0;
@@ -102,7 +161,7 @@
     }
   }
 
-  /* Exit keyframes */
+  /* Exit 애니메이션 키프레임 */
   @keyframes slide-down-out {
     from {
       opacity: 1;
@@ -113,6 +172,7 @@
       transform: translateY(50px);
     }
   }
+
   @keyframes slide-left-out {
     from {
       opacity: 1;
@@ -123,6 +183,7 @@
       transform: translateX(-50px);
     }
   }
+
   @keyframes slide-right-out {
     from {
       opacity: 1;
@@ -133,6 +194,7 @@
       transform: translateX(50px);
     }
   }
+
   @keyframes fade-out {
     from {
       opacity: 1;
@@ -141,6 +203,7 @@
       opacity: 0;
     }
   }
+
   @keyframes scale-out {
     from {
       opacity: 1;
@@ -152,7 +215,7 @@
     }
   }
 
-  /* Enter utilities data-visible=true */
+  /* 애니메이션 유틸리티 클래스 */
   .animate-slide-up {
     animation: slide-up 0.5s ease-in-out both;
   }
@@ -169,7 +232,7 @@
     animation: scale-in 0.35s ease-out both;
   }
 
-  /* Exit utilities: data-visible=false */
+  /* Exit 애니메이션 유틸리티 */
   [data-visible="false"].animate-slide-up {
     animation: slide-down-out 0.5s ease-in-out forwards;
   }
@@ -186,7 +249,7 @@
     animation: scale-out 0.35s ease-out forwards;
   }
 
-  /* 반응형 애니메이션 클래스 추가 - 더 높은 특이성으로 정의 */
+  /* 반응형 애니메이션 유틸리티 */
   @media (min-width: 1024px) {
     .lg\:animate-slide-left {
       animation: slide-left 0.5s ease-in-out both !important;
@@ -195,12 +258,95 @@
       animation: slide-right 0.5s ease-in-out both !important;
     }
 
-    /* 데스크톱에서의 퇴장(반대 방향) */
     [data-visible="false"].lg\:animate-slide-left {
       animation: slide-left-out 0.4s ease-in-out forwards !important;
     }
     [data-visible="false"].lg\:animate-slide-right {
       animation: slide-right-out 0.4s ease-in-out forwards !important;
+    }
+  }
+}
+
+/* 프로젝트 카드 인터랙션 - 데스크탑 */
+@media (hover: hover) and (pointer: fine) {
+  .mobile-buttons {
+    @apply hidden;
+  }
+
+  .hover-overlay {
+    @apply flex;
+  }
+
+  .project-card:hover {
+    transform: translateY(-0.5rem);
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  }
+
+  .project-card:hover .hover-overlay {
+    opacity: 1;
+  }
+
+  .project-card:hover .project-image {
+    opacity: 0.5;
+  }
+}
+
+/* 프로젝트 카드 인터랙션 - 모바일 */
+@media (hover: none) {
+  .project-card:hover {
+    transform: none;
+    box-shadow: none;
+  }
+
+  .mobile-buttons {
+    @apply flex;
+  }
+
+  .hover-overlay {
+    @apply hidden;
+  }
+}
+
+/* 스킬 컴포넌트 인터랙션 - 데스크탑 */
+@media (hover: hover) and (pointer: fine) {
+  /* 큰 화면: 텍스트 표시 */
+  @media (min-width: 768px) {
+    .skill-text {
+      @apply block text-sm;
+    }
+  }
+
+  /* 작은 화면: 텍스트 숨기고 hover 툴팁 */
+  @media (max-width: 767px) {
+    .skill-text {
+      @apply hidden;
+    }
+
+    .skill-item:hover .skill-tooltip {
+      @apply opacity-100;
+    }
+  }
+
+  .skill-item:hover {
+    @apply shadow-[0_0_20px_rgba(16,185,129,1)] dark:shadow-[0_0_30px_rgba(16,255,200,0.3)];
+  }
+}
+
+/* 스킬 컴포넌트 인터랙션 - 모바일 */
+@media (hover: none) {
+  @media (min-width: 768px) {
+    .skill-text {
+      @apply block text-sm;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .skill-text {
+      @apply hidden;
+    }
+
+    .skill-item.clicked .skill-tooltip {
+      @apply opacity-100;
     }
   }
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,10 +1,14 @@
 export function Footer() {
   return (
     <footer
-      className={`text-black dark:text-white bg-stone-200 dark:bg-gray-900 text-lg text-center py-8`}
+      className={`text-black dark:text-white bg-stone-200 dark:bg-gray-900 text-center py-8`}
       id="footer"
     >
-      Copyright 2025. KIM UIHYEON. All rights reserved.
+      <div className={`section-container`}>
+        <p>
+          <small>Copyright 2025. KIM UIHYEON. All rights reserved.</small>
+        </p>
+      </div>
     </footer>
   );
 }

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -16,8 +16,8 @@ export function About({ aboutData }: AboutProps) {
       id="about"
     >
       <div className={`section-container`}>
-        <AnimatedSection className={`animate-fade text-center mb-16`}>
-          <h2 className={`section-header text-3xl md:text-4xl`}>About Me</h2>
+        <AnimatedSection className={`animate-fade text-center`}>
+          <h2 className={`section-header`}>About Me</h2>
         </AnimatedSection>
         <AboutContent aboutData={aboutData} />
       </div>

--- a/src/components/sections/AboutContent.tsx
+++ b/src/components/sections/AboutContent.tsx
@@ -22,15 +22,13 @@ export function AboutContent({ aboutData }: AboutContentProps) {
     <div className={`grid lg:grid-cols-2 gap-12 items-center`}>
       {aboutData.profileImageUrl && (
         <AnimatedSection className={`animate-slide-up lg:animate-slide-left`}>
-          <div
-            className={`relative mx-auto w-fit bg-emerald-300/40 dark:bg-emerald-200/60 p-4 rounded-2xl shadow-lg`}
-          >
-            <div className={`relative w-64 h-80 lg:w-72 lg:h-96`}>
+          <div className="relative mx-auto w-[clamp(16rem,30vw,18rem)] h-[clamp(20rem,35vw,24rem)] bg-emerald-300/40 dark:bg-emerald-200/60 p-[clamp(0.875rem,2vw,1rem)] rounded-2xl shadow-lg">
+            <div className="relative w-full h-full">
               <Image
                 fill
                 priority
                 alt="김의현 프로필 사진"
-                className={`rounded-xl object-cover`}
+                className="rounded-xl object-cover"
                 sizes="(max-width: 1024px) 256px, 288px"
                 src={aboutData.profileImageUrl}
               />
@@ -43,7 +41,7 @@ export function AboutContent({ aboutData }: AboutContentProps) {
         className={`animate-slide-up lg:animate-slide-right space-y-6 text-center lg:text-left`}
       >
         <h3
-          className={`flex justify-center lg:justify-start items-center text-2xl font-semibold text-gray-900 dark:text-white mb-4`}
+          className={`flex justify-center lg:justify-start items-center font-semibold text-gray-900 dark:text-white mb-4`}
         >
           안녕하세요! 프론트엔드 개발자 김의현입니다
           <SlEmotsmile
@@ -65,7 +63,7 @@ export function AboutContent({ aboutData }: AboutContentProps) {
               delay={index * 0.1}
             >
               <span
-                className={`px-3 py-1 bg-emerald-300/30 text-black dark:text-white rounded-full text-sm font-medium`}
+                className={`text-sm px-3 py-1 bg-emerald-300/30 text-black dark:text-white rounded-full font-medium`}
               >
                 {keyword}
               </span>
@@ -78,18 +76,22 @@ export function AboutContent({ aboutData }: AboutContentProps) {
           delay={0.3}
         >
           <a
-            className="primary-button px-6 py-3 rounded-lg"
+            className={`primary-button px-[clamp(1rem,4vw,1.5rem)] py-[clamp(0.5rem,2vw,0.75rem)] rounded-lg`}
             href="/api/download/resume"
           >
-            <BsDownload className="w-6 h-6 mr-3" />
+            <BsDownload
+              className={`w-[clamp(1rem,4vw,1.5rem)] h-[clamp(1rem,4vw,1.5rem)] mr-3`}
+            />
             이력서 다운로드
           </a>
 
           <a
-            className="primary-button px-6 py-3 rounded-lg"
+            className={`primary-button px-[clamp(1rem,4vw,1.5rem)] py-[clamp(0.5rem,2vw,0.75rem)] rounded-lg`}
             href="/api/download/workExperience"
           >
-            <BsDownload className="w-6 h-6 mr-3" />
+            <BsDownload
+              className={`w-[clamp(1rem,4vw,1.5rem)] h-[clamp(1rem,4vw,1.5rem)] mr-3`}
+            />
             경력기술서 다운로드
           </a>
         </AnimatedSection>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -17,45 +17,40 @@ export function Contact({ aboutData }: ContactProps) {
       className="section-padding bg-stone-100 dark:bg-gray-800"
       id="contact"
     >
-      <div className={`section-container`}>
-        <div className="section-container text-center">
-          <AnimatedSection className={`animate-fade text-center mb-16`}>
-            <h2 className="section-header text-3xl md:text-4xl">Contact</h2>
-          </AnimatedSection>
+      <div className="section-container text-center">
+        <AnimatedSection className={`animate-fade text-center`}>
+          <h2 className={`section-header`}>Contact</h2>
+        </AnimatedSection>
 
-          <AnimatedSection className={`animate-scale`} delay={0.1}>
-            <p className="text-2xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-              더 궁금한 점이 있으시면 언제든 연락주세요!
-            </p>
-            <p className="text-2xl text-gray-600 dark:text-gray-300 mt-4 mb-12">
-              감사합니다 🙏
-            </p>
+        <AnimatedSection className={`animate-scale`} delay={0.1}>
+          <p className="text-gray-800 dark:text-gray-300 max-w-2xl mx-auto">
+            더 궁금한 점이 있으시면 언제든 연락주세요!
+          </p>
+          <p className="text-gray-800 dark:text-gray-300 mt-4 mb-10">
+            감사합니다 🙏
+          </p>
 
-            <div className="space-y-4 border-4 border-emerald-500 rounded-lg p-6 max-w-sm mx-auto">
+          <div className="space-y-4 border-4 border-emerald-500 rounded-lg p-6 max-w-sm mx-auto">
+            <dl>
               {aboutData.email && (
-                <>
-                  <p className="text-gray-600 dark:text-gray-300 text-sm mb-1">
-                    Email
-                  </p>
-                  <p className="text-xl font-medium text-emerald-600 dark:text-emerald-400">
+                <div className={`mb-4`}>
+                  <dt className="text-gray-600 dark:text-gray-300">Email</dt>
+                  <dd className="font-medium text-emerald-600 dark:text-emerald-400">
                     {aboutData.email}
-                  </p>
-                </>
+                  </dd>
+                </div>
               )}
-
               {aboutData.phone && (
-                <>
-                  <p className="text-gray-600 dark:text-gray-300 text-sm mb-1">
-                    Phone
-                  </p>
-                  <p className="text-xl font-medium text-emerald-600 dark:text-emerald-400">
+                <div>
+                  <dt className="text-gray-600 dark:text-gray-300">Phone</dt>
+                  <dd className="font-medium text-emerald-600 dark:text-emerald-400">
                     {aboutData.phone}
-                  </p>
-                </>
+                  </dd>
+                </div>
               )}
-            </div>
-          </AnimatedSection>
-        </div>
+            </dl>
+          </div>
+        </AnimatedSection>
       </div>
     </section>
   );

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -33,7 +33,7 @@ export function Hero({ aboutData }: HeroProps) {
       <div className="section-container relative z-10">
         <div className="text-center max-w-4xl mx-auto">
           <AnimatedTitle
-            className="text-4xl md:text-6xl lg:text-7xl font-bold text-gray-900 dark:text-white mb-6"
+            className="font-bold text-gray-900 dark:text-white mb-6"
             delay={0.3}
           >
             안녕하세요,{" "}
@@ -48,7 +48,7 @@ export function Hero({ aboutData }: HeroProps) {
           </AnimatedSubtitle>
 
           <AnimatedParagraph
-            className="text-lg text-gray-600 dark:text-gray-300 mb-12 max-w-2xl mx-auto leading-relaxed"
+            className="text-gray-600 dark:text-gray-300 mb-12 max-w-2xl mx-auto leading-relaxed"
             delay={0.5}
           >
             단순함 속에서 편리함을, 편리함 속에서 즐거움을

--- a/src/components/sections/HeroTyping.tsx
+++ b/src/components/sections/HeroTyping.tsx
@@ -36,11 +36,11 @@ export function HeroTyping() {
   }, [currentText, currentIndex, isTyping]);
 
   return (
-    <h2
-      className={`text-3xl md:text-3xl font-semibold text-gray-700 dark:text-gray-200 min-h-[3rem]`}
+    <p
+      className={`font-semibold text-gray-700 dark:text-gray-200 min-h-[3rem]`}
     >
       {currentText}
       <span className={`animate-pulse`}>|</span>
-    </h2>
+    </p>
   );
 }

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -8,6 +8,9 @@ async function getProjects() {
       info: true,
       tasks: true,
     },
+    orderBy: {
+      id: "asc",
+    },
   });
   return projects;
 }
@@ -21,8 +24,8 @@ export async function Projects() {
       id="projects"
     >
       <div className={`section-container`}>
-        <AnimatedSection className={`animate-fade text-center mb-16`}>
-          <h2 className={`section-header text-3xl md:text-4xl `}>Projects</h2>
+        <AnimatedSection className={`animate-fade text-center`}>
+          <h2 className={`section-header`}>Projects</h2>
         </AnimatedSection>
 
         <ProjectList projects={projects} />

--- a/src/components/sections/SkillList.tsx
+++ b/src/components/sections/SkillList.tsx
@@ -2,7 +2,7 @@
 
 import { SkillsData } from "@/types";
 import Image from "next/image";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { AnimatedSection } from "../common/AnimatedSection";
 
 const CATEGORIES = {
@@ -23,6 +23,23 @@ export function SkillList({ skills }: SkillListProps) {
   const [activeCategory, setActiveCategory] = useState<SkillCategory>(
     CATEGORIES.All,
   );
+  const [clickedSkill, setClickedSkill] = useState<string | null>(null);
+
+  const handleSkillClick = (skillName: string) => {
+    setClickedSkill((prev) => (prev === skillName ? null : skillName));
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: Event) => {
+      const target = event.target as Element;
+      if (clickedSkill && !target.closest(".skill-item")) {
+        setClickedSkill(null);
+      }
+    };
+
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, [clickedSkill]);
 
   return (
     <>
@@ -31,7 +48,7 @@ export function SkillList({ skills }: SkillListProps) {
           {Object.values(CATEGORIES).map((category) => (
             <button
               key={category}
-              className={`px-6 py-3 rounded-full font-medium transition-all duration-300 ${
+              className={`primary-button px-[clamp(1rem,4vw,1.5rem)] py-[clamp(0.5rem,2vw,0.75rem)] rounded-full font-medium transition-all duration-300 ${
                 activeCategory === category
                   ? "bg-emerald-500/70 text-white shadow-lg"
                   : "bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
@@ -50,32 +67,30 @@ export function SkillList({ skills }: SkillListProps) {
         {skills.All.map((skill, index) => (
           <AnimatedSection
             key={skill.name}
-            className={`animate-slide-up relative flex flex-col items-center justify-center gap-2 p-4 bg-white dark:bg-gray-900/50 rounded-lg shadow-md transition-all duration-300 ${
+            className={`animate-slide-up skill-item relative flex flex-col items-center justify-center gap-2 p-4 bg-white dark:bg-gray-900/50 rounded-lg shadow-md transition-all duration-300 cursor-pointer ${
               activeCategory === "All" || activeCategory === skill.category
                 ? "group hover:scale-105"
                 : "blur-md opacity-15 pointer-events-none"
-            }`}
+            } ${clickedSkill === skill.name ? "clicked" : ""}`}
             delay={index * 0.02}
           >
-            <div className={`text-4xl`}>
+            <div onClick={() => handleSkillClick(skill.name)}>
               <Image
                 alt={skill.name}
+                className={`w-[clamp(1.5rem,4vw,2.25rem)] h-[clamp(1.5rem,4vw,2.25rem)]`}
                 height={36}
                 src={skill.icon}
-                style={{ width: "36px", height: "36px" }}
                 width={36}
               />
             </div>
+
             <p
-              className={`hidden md:block font-semibold text-gray-800 dark:text-gray-200 text-center text-sm`}
+              className={`skill-text font-medium dark:font-light text-black dark:text-gray-200 text-center`}
             >
               {skill.name}
             </p>
-            <div
-              className={`md:hidden absolute bottom-full mb-2 px-3 py-1.5 bg-gray-900 text-white dark:bg-white dark:text-gray-900 rounded-lg shadow-lg text-sm opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none`}
-            >
-              {skill.name}
-            </div>
+
+            <div className={`skill-tooltip`}>{skill.name}</div>
           </AnimatedSection>
         ))}
       </div>

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -42,8 +42,8 @@ export async function Skills() {
       id="skills"
     >
       <div className={`section-container`}>
-        <AnimatedSection className={`animate-fade text-center mb-16`}>
-          <h2 className={`section-header text-3xl md:text-4xl `}>Skills</h2>
+        <AnimatedSection className={`animate-fade text-center`}>
+          <h2 className={`section-header`}>Skills</h2>
         </AnimatedSection>
         <SkillList skills={skills} />
       </div>

--- a/src/components/ui/CollapsibleSection.tsx
+++ b/src/components/ui/CollapsibleSection.tsx
@@ -21,9 +21,9 @@ export function CollapsibleSection({ task }: CollapsibleSectionProps) {
         className={`w-full px-4 py-4 bg-stone-200 dark:bg-gray-700 hover:bg-stone-300 dark:hover:bg-gray-800 transition-colors flex items-center justify-between text-left`}
         onClick={() => setIsOpen(!isOpen)}
       >
-        <h3 className={`font-semibold text-gray-900 dark:text-white`}>
+        <h4 className={`font-medium text-gray-900 dark:text-white`}>
           {task.title}
-        </h3>
+        </h4>
         <motion.div
           animate={{ rotate: isOpen ? 180 : 0 }}
           transition={{ duration: 0.2 }}
@@ -49,11 +49,11 @@ export function CollapsibleSection({ task }: CollapsibleSectionProps) {
                   className={`w-1 h-auto bg-blue-500 rounded-full my-1`}
                 ></div>
                 <div className={`flex-1`}>
-                  <h4
-                    className={`flex items-center text-lg font-semibold text-gray-800 dark:text-gray-200`}
+                  <h5
+                    className={`flex items-center font-semibold text-gray-800 dark:text-gray-200`}
                   >
                     이슈
-                  </h4>
+                  </h5>
                   <div
                     className={`flex items-start mt-2 text-gray-700 dark:text-gray-300`}
                   >
@@ -74,11 +74,11 @@ export function CollapsibleSection({ task }: CollapsibleSectionProps) {
                   className={`w-1 h-auto bg-green-500 rounded-full my-1`}
                 ></div>
                 <div className={`flex-1`}>
-                  <h4
-                    className={`flex items-center text-lg font-semibold text-gray-800 dark:text-gray-200`}
+                  <h5
+                    className={`flex items-center font-semibold text-gray-800 dark:text-gray-200`}
                   >
                     해결
-                  </h4>
+                  </h5>
                   <ul
                     className={`list-disc list-inside mt-2 space-y-1 text-gray-700 dark:text-gray-300`}
                   >
@@ -103,11 +103,11 @@ export function CollapsibleSection({ task }: CollapsibleSectionProps) {
                   className={`w-1 h-auto bg-purple-500 rounded-full my-1`}
                 ></div>
                 <div className={`flex-1`}>
-                  <h4
-                    className={`flex items-center text-lg font-semibold text-gray-800 dark:text-gray-200`}
+                  <h5
+                    className={`flex items-center font-semibold text-gray-800 dark:text-gray-200`}
                   >
                     성과
-                  </h4>
+                  </h5>
                   <ul
                     className={`list-disc list-inside mt-2 space-y-1 text-gray-700 dark:text-gray-300`}
                   >

--- a/src/components/ui/EmailCopyButton.tsx
+++ b/src/components/ui/EmailCopyButton.tsx
@@ -42,7 +42,7 @@ export function EmailCopyButton({ email }: EmailCopyButtonProps) {
         {isEmailCopied && (
           <motion.div
             animate={{ opacity: 1, y: 0 }}
-            className="absolute top-16 left-1/2 -translate-x-1/2 px-3 py-1.5 text-sm bg-gray-900 text-white dark:bg-white dark:text-gray-900 rounded-lg shadow-lg whitespace-nowrap"
+            className="absolute top-16 left-1/2 -translate-x-1/2 px-3 py-1.5 text-sm bg-emerald-400/70 text-white rounded-lg shadow-lg whitespace-nowrap"
             exit={{ opacity: 0, y: 10 }}
             initial={{ opacity: 0, y: 10 }}
             transition={{ duration: 0.2 }}

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -1,5 +1,4 @@
 import { Project } from "@/types";
-import Image from "next/image";
 import Link from "next/link";
 import { HiOutlineArrowRight } from "react-icons/hi";
 
@@ -10,68 +9,67 @@ interface ProjectCardProps {
 export function ProjectCard({ project }: ProjectCardProps) {
   return (
     <section
-      className={`overflow-hidden flex flex-col justify-start gap-8 rounded-2xl bg-stone-100 dark:bg-gray-800
-         relative h-[23rem] group transition-transform duration-300 ease-out hover:shadow-xl
-         hover:-translate-y-2`}
+      className={`project-card overflow-hidden flex flex-col justify-start gap-8 rounded-2xl bg-stone-100 dark:bg-gray-800
+         relative h-[20rem] group transition-transform duration-300 ease-out`}
       id="ProjectCard"
     >
-      {project.image && (
-        <div className={`relative h-48 overflow-hidden`}>
-          <Image
-            alt={project.title}
-            className={`transition-opacity group-hover:opacity-50`}
-            layout="fill"
-            loading="lazy"
-            objectFit="cover"
-            src={project.image as string}
-          />
-        </div>
-      )}
-
       <div className={`p-6 flex-grow flex flex-col`}>
-        <div className={`flex items-center mb-3`}>
-          <div
-            className={`px-2 py-1 bg-emerald-300/50 dark:bg-emerald-400/40 text-gray-600 dark:text-gray-200 rounded-full text-sm font-semibold mr-2`}
+        <div className={`text-sm flex items-center mb-3`}>
+          <span
+            className={`px-2 py-1 bg-emerald-300/50 dark:bg-emerald-400/40 text-gray-800 dark:text-gray-200 rounded-full font-medium mr-2`}
           >
             {project.info?.name}
-          </div>
-          <span className={`text-gray-600 dark:text-gray-400 text-sm`}>
+          </span>
+          <span className={`text-gray-600 dark:text-gray-400`}>
             {project.info?.period}
           </span>
         </div>
 
-        <h2
-          className={`text-[clamp(1.25rem,1.8vw,1.3rem)] font-semibold dark:text-white mb-1 pb-2`}
-        >
+        <h3 className={`font-semibold dark:text-white mb-1 pb-2`}>
           {project.title}
-        </h2>
-        <div
-          className={`flex items-start text-gray-700 dark:text-gray-300 text-sm mb-2`}
-        >
+        </h3>
+        <p className={`flex items-start text-gray-800 dark:text-gray-300 mb-4`}>
           <HiOutlineArrowRight
             className={`w-4 h-4 mt-1.5 mr-2 text-green-500 flex-shrink-0`}
           />
           {project.summary}
-        </div>
-      </div>
+        </p>
 
-      <div
-        className={`absolute z-[3] flex flex-col items-center justify-center gap-10 text-black dark:text-white w-full
-           h-full p-5 hover:bg-stone-100 dark:hover:bg-gray-800 opacity-0 transition group-hover:opacity-100`}
-      >
-        <h3 className={`font-bold text-2xl group-hover:text-center`}>
-          {project.title}
-        </h3>
-        <div className={`w-2/3 flex flex-col gap-3`}>
+        <div className={`mobile-buttons mt-auto flex-col gap-2`}>
           <Link
-            className={`primary-button px-6 py-3 rounded-lg text-center`}
+            className={`primary-button px-4 py-2 rounded-lg text-center block`}
             href={`/${project.slug}`}
           >
             자세히보기
           </Link>
           {project.githubUrl && (
             <a
-              className={`primary-button px-6 py-3 rounded-lg`}
+              className={`primary-button px-4 py-2 rounded-lg block mt-2`}
+              href={project.githubUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Github 바로가기
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div
+        className={`hover-overlay absolute z-[3] flex flex-col items-center justify-center gap-10 text-black dark:text-white w-full
+           h-full p-5 bg-stone-100 dark:bg-gray-800 opacity-0 transition-opacity duration-300`}
+      >
+        <h3 className={`font-semibold text-center`}>{project.title}</h3>
+        <div className={`w-2/3 flex flex-col gap-3`}>
+          <Link
+            className={`primary-button px-[clamp(1rem,4vw,1.5rem)] py-[clamp(0.5rem,2vw,0.75rem)] rounded-lg text-center`}
+            href={`/${project.slug}`}
+          >
+            자세히보기
+          </Link>
+          {project.githubUrl && (
+            <a
+              className={`primary-button px-[clamp(1rem,4vw,1.5rem)] py-[clamp(0.5rem,2vw,0.75rem)] rounded-lg`}
               href={project.githubUrl}
               rel="noopener noreferrer"
               target="_blank"

--- a/src/components/ui/ProjectModal.tsx
+++ b/src/components/ui/ProjectModal.tsx
@@ -27,23 +27,20 @@ export function ProjectModal({ project }: ProjectModalProps) {
     <ProjectModalClient>
       <div className={`-mt-12 pt-4`}>
         <div className={`flex items-start justify-between mb-6`}>
-          <h2
-            className={`text-2xl md:text-3xl font-bold text-gray-900 dark:text-white pr-16`}
-          >
+          <h3 className={`font-bold text-gray-900 dark:text-white pr-16`}>
             {project.title}
-          </h2>
+          </h3>
         </div>
 
         <div className={`space-y-6`}>
           <div
-            className={`flex items-center text-sm text-gray-600 dark:text-gray-400`}
+            className={`text-sm flex items-center text-gray-600 dark:text-gray-400`}
           >
             {renderIcon()}
-            <span
-              className={`font-semibold text-lg mr-2 text-gray-700 dark:text-gray-300`}
-            >
+            <p className={`font-semibold text-gray-700 dark:text-gray-300`}>
               {project.info?.name}
-            </span>
+            </p>
+            <span className="w-[1px] bg-gray-400 mx-1 self-stretch"></span>
             {project.info?.members && (
               <span className={`text-gray-600 dark:text-gray-400`}>
                 ({project.info?.members})
@@ -51,19 +48,17 @@ export function ProjectModal({ project }: ProjectModalProps) {
             )}
           </div>
 
-          <div
-            className={`flex items-center text-sm text-gray-600 dark:text-gray-400`}
-          >
+          <div className={`flex items-center text-gray-600 dark:text-gray-400`}>
             <FcCalendar className={`w-4 h-4 mr-2`} />
             <span>{project.info?.period}</span>
           </div>
 
           <div>
-            <h3
-              className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
+            <h4
+              className={`font-semibold mb-3 text-gray-900 dark:text-gray-100`}
             >
               프로젝트 설명
-            </h3>
+            </h4>
             <ul className={`list-disc list-inside space-y-2`}>
               {project.descriptions.map((desc, index) => (
                 <li key={index} className={`flex items-start`}>
@@ -81,16 +76,16 @@ export function ProjectModal({ project }: ProjectModalProps) {
           </div>
 
           <div>
-            <h3
-              className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
+            <h4
+              className={`font-semibold mb-3 text-gray-900 dark:text-gray-100`}
             >
               사용 기술
-            </h3>
+            </h4>
             <div className={`flex flex-wrap gap-2`}>
               {project.technologies.map((tech, index) => (
                 <span
                   key={index}
-                  className={`bg-stone-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 px-3 py-1 rounded-full text-sm`}
+                  className={`font-light text-sm bg-stone-200 text-black dark:bg-gray-700 dark:text-gray-200 px-3 py-1 rounded-full`}
                 >
                   {tech}
                 </span>
@@ -101,11 +96,9 @@ export function ProjectModal({ project }: ProjectModalProps) {
           <div
             className={`border-t border-gray-400 dark:border-gray-700 pt-6 space-y-4`}
           >
-            <h3
-              className={`font-semibold text-xl mb-3 text-gray-900 dark:text-gray-100`}
-            >
-              주요 업무 및 성과
-            </h3>
+            <h4 className={`mb-3 text-gray-900 dark:text-gray-100`}>
+              <strong>주요 업무 및 성과</strong>
+            </h4>
             {project.tasks.map((task) => (
               <CollapsibleSection key={task.id} task={task} />
             ))}


### PR DESCRIPTION
- 반응형 디자인
  - `clamp()` 함수를 사용해 폰트 크기를 뷰포트 너비에 따라 자동으로 조절하도록 설정 (`h`, `p`, `small` 태그 등)
- `glabals.css` 정리
  - `@layer` 지시어에 맞게 스타일을 `base`, `components`, `utilities` 세 가지 레이어로 분류
    - `base` : 공통 스타일
    - `components` : 재사용 가능한 UI 컴포넌트 스타일 클래스
    - `utilities` : 애니메이션처럼 특정 목적을 가진 유틸리티 클래스
- skill 관련 모바일/데스크탑 ui개선
  - 화면 크기가 작아지면 skill의 text가 안보이도록 설정했음
    - desktop : `hover`시 text가 tooltip으로 보이도록 설정
    - mobile : `click`시 text가 tooltip으로 보이도록 설정