### PR TITLE
[fix] 동적 라우팅 await 오류 해결

### DIFF
--- a/src/app/@modal/(.)[slug]/page.tsx
+++ b/src/app/@modal/(.)[slug]/page.tsx
@@ -3,14 +3,13 @@ import { getProjectBySlug } from "@/lib/projects";
 import { notFound } from "next/navigation";
 
 interface ModalPageProps {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }
 
 export default async function InterceptedProjectModal({
   params,
 }: ModalPageProps) {
-  const { slug } = await params;
-  const project = await getProjectBySlug(slug);
+  const project = await getProjectBySlug((await params).slug);
 
   if (!project) {
     notFound();

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -3,12 +3,11 @@ import { getProjectBySlug } from "@/lib/projects";
 import { notFound } from "next/navigation";
 
 interface ProjectPageProps {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }
 
 export default async function ProjectPage({ params }: ProjectPageProps) {
-  const { slug } = await params;
-  const project = await getProjectBySlug(slug);
+  const project = await getProjectBySlug((await params).slug);
 
   if (!project) {
     notFound();


### PR DESCRIPTION
- Next.js의 동적 라우팅 파라미터(`param`)를 사용하는 과정에서 빌드, 런타임에 오류가 발생
  - `app/[slug]/page.tsx`, `app/@modal/(.)[slug]/page`
- 빌드 에러
  - `params`를 `{ slug: string }`으로 정의했지만, Next.js에서 `Promise`타입으로 기대해 타입이 불일치하는 문제가 발생
- 런타임 에러
  - `await`없이 `params`의 속성(`params.slug`)에 접근하면, Next.js는 `params`가 `await`되어야 한다는 경고와 함께 런타임 오류를 발생시킴
- 해결
  - Next.js 공식 문서에 나와있는 것처럼 `params`를 `Promise` 타입으로 명시하고, `await`를 사용하여 속성에 접근하도록 수정