### PR TITLE
[fix] Modal Navigation 오류 해결

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -16,7 +16,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
   return (
     <main className="min-h-screen bg-white dark:bg-gray-900">
       <div className="container mx-auto px-4 py-8">
-        <ProjectModal project={project} />
+        <ProjectModal project={project} returnUrl={"/"} />
       </div>
     </main>
   );

--- a/src/components/ui/ProjectModal.tsx
+++ b/src/components/ui/ProjectModal.tsx
@@ -7,9 +7,10 @@ import { FcCalendar } from "react-icons/fc";
 
 interface ProjectModalProps {
   project: Project;
+  returnUrl?: string;
 }
 
-export function ProjectModal({ project }: ProjectModalProps) {
+export function ProjectModal({ project, returnUrl }: ProjectModalProps) {
   const renderIcon = () => {
     switch (project.info?.type) {
       case "Company":
@@ -24,7 +25,7 @@ export function ProjectModal({ project }: ProjectModalProps) {
   };
 
   return (
-    <ProjectModalClient>
+    <ProjectModalClient returnUrl={returnUrl}>
       <div className={`-mt-12 pt-4`}>
         <div className={`flex items-start justify-between mb-6`}>
           <h3 className={`font-bold text-gray-900 dark:text-white pr-16`}>

--- a/src/components/ui/ProjectModalClient.tsx
+++ b/src/components/ui/ProjectModalClient.tsx
@@ -1,20 +1,32 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { IoMdClose } from "react-icons/io";
 
 interface ProjectModalClientProps {
   children: React.ReactNode;
+  returnUrl?: string;
 }
 
-export function ProjectModalClient({ children }: ProjectModalClientProps) {
+export function ProjectModalClient({
+  children,
+  returnUrl,
+}: ProjectModalClientProps) {
   const router = useRouter();
+
+  const handleClose = useCallback(() => {
+    if (returnUrl) {
+      router.push("/");
+    } else {
+      router.back();
+    }
+  }, [returnUrl, router]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        router.back();
+        handleClose();
       }
     };
 
@@ -25,15 +37,7 @@ export function ProjectModalClient({ children }: ProjectModalClientProps) {
       window.removeEventListener("keydown", handleKeyDown);
       document.body.style.overflow = "unset";
     };
-  }, [router]);
-
-  const handleCloseClick = () => {
-    if (window.history.length > 2) {
-      router.back();
-    } else {
-      router.push("/");
-    }
-  };
+  }, [handleClose]);
 
   return (
     <div
@@ -46,7 +50,7 @@ export function ProjectModalClient({ children }: ProjectModalClientProps) {
         <button
           aria-label="Close modal"
           className={`primary-button sticky top-0 left-full ml-4 -mt-1 -mr-1 z-10 rounded-full px-2 py-2 close-button`}
-          onClick={handleCloseClick}
+          onClick={handleClose}
         >
           <IoMdClose className={`w-5 h-5`} />
         </button>


### PR DESCRIPTION
- 문제
  - 외부에서 `url/project`로 직접 접근 시 `router.back()`을 통해 이전 페이지로 돌아감
  - 원래는 `url/project`로 직접 접근 시 `"/"`으로 가는 걸 예상
- 해결
  - ProjectModalClient에 returnUrl props를 추가
  - 직접 접근 페이지는 `returnUrl="/"` 전달
  - Modal route는 props없이 `router.back()` 사용