### PR TITLE
[fix] 프로젝트 상세 라우트 사전 생성 및 ISR 적용

### DIFF
--- a/src/app/@modal/(.)[slug]/page.tsx
+++ b/src/app/@modal/(.)[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { ProjectModal } from "@/components/ui/ProjectModal";
-import { getProjectBySlug } from "@/lib/projects";
+import { getProjectBySlug, getProjectSlugs } from "@/lib/projects";
 import { notFound } from "next/navigation";
 
 interface ModalPageProps {
@@ -7,6 +7,10 @@ interface ModalPageProps {
 }
 
 export const revalidate = 86400; // 24시간마다 ISR로 페이지를 재생성
+
+export async function generateStaticParams() {
+  return getProjectSlugs();
+}
 
 export default async function InterceptedProjectModal({
   params,

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { ProjectModal } from "@/components/ui/ProjectModal";
-import { getProjectBySlug } from "@/lib/projects";
+import { getProjectBySlug, getProjectSlugs } from "@/lib/projects";
 import { notFound } from "next/navigation";
 
 interface ProjectPageProps {
@@ -7,6 +7,10 @@ interface ProjectPageProps {
 }
 
 export const revalidate = 86400; // 24시간마다 ISR로 페이지를 재생성
+
+export async function generateStaticParams() {
+  return getProjectSlugs();
+}
 
 export default async function ProjectPage({ params }: ProjectPageProps) {
   const project = await getProjectBySlug((await params).slug);

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,6 +1,12 @@
 import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 
+export async function getProjectSlugs() {
+  return prisma.project.findMany({
+    select: { slug: true },
+  });
+}
+
 export const getProjectBySlug = unstable_cache(
   async (slug: string) => {
     try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
- generateStaticParams로 프로젝트 상세 경로를 빌드 시 생성
- 일반 상세 페이지와 인터셉트 모달 라우트에 사전 생성 적용
- 24시간 주기의 ISR 설정 유지
- 상세 페이지 첫 접근 시 서버리스 렌더링 지연 개선